### PR TITLE
Insert new automated TCs for Posting/Editing

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1421,7 +1421,6 @@
 		93F2E5421E9E5A350050D489 /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93F2E5411E9E5A350050D489 /* QuickLook.framework */; };
 		93F2E5441E9E5A570050D489 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93F2E5431E9E5A570050D489 /* CoreSpotlight.framework */; };
 		93FA59DD18D88C1C001446BC /* PostCategoryService.m in Sources */ = {isa = PBXBuildFile; fileRef = 93FA59DC18D88C1C001446BC /* PostCategoryService.m */; };
-		976E325EAC3B33524407BFC0 /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
 		9804A097263780B500354097 /* LikeUserHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9804A096263780B400354097 /* LikeUserHelpers.swift */; };
 		9804A098263780B500354097 /* LikeUserHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9804A096263780B400354097 /* LikeUserHelpers.swift */; };
 		98077B5A2075561800109F95 /* SupportTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98077B592075561800109F95 /* SupportTableViewController.swift */; };
@@ -7617,7 +7616,6 @@
 			files = (
 				3FA640622670CE260064401E /* UITestsFoundation.framework in Frameworks */,
 				2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */,
-				976E325EAC3B33524407BFC0 /* Pods_WordPressScreenshotGeneration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14714,7 +14712,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1220;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = WordPress;
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
@@ -22044,6 +22042,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -22548,6 +22547,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -23320,6 +23320,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -23376,6 +23377,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/JetpackScreenshotGeneration.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/JetpackScreenshotGeneration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/OCLint.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/OCLint.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Internal.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Internal.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressIntents.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressIntents.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1250"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressScreenshotGeneration.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressScreenshotGeneration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -20,15 +20,6 @@
             </ActionContent>
          </ExecutionAction>
       </PreActions>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
-            BuildableName = "WordPress.app"
-            BlueprintName = "WordPress"
-            ReferencedContainer = "container:WordPress.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressShareExtension.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressShareExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressStatsWidgets.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressStatsWidgets.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressTodayWidget.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressTodayWidget.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPressUITests/Screens/ActionSheetComponent.swift
+++ b/WordPress/WordPressUITests/Screens/ActionSheetComponent.swift
@@ -2,15 +2,18 @@ import UITestsFoundation
 import XCTest
 
 class ActionSheetComponent: BaseScreen {
+    let storyPostbutton: XCUIElement
     let blogPostButton: XCUIElement
     let sitePageButton: XCUIElement
 
     struct ElementIDs {
+        static let storyPostButton = "storyButton"
         static let blogPostButton = "blogPostButton"
         static let sitePageButton = "sitePageButton"
     }
 
     init() {
+        storyPostbutton = XCUIApplication().buttons[ElementIDs.storyPostButton]
         blogPostButton = XCUIApplication().buttons[ElementIDs.blogPostButton]
         sitePageButton = XCUIApplication().buttons[ElementIDs.sitePageButton]
 
@@ -20,7 +23,6 @@ class ActionSheetComponent: BaseScreen {
     func gotoBlogPost() {
         XCTAssert(blogPostButton.waitForExistence(timeout: 3))
         XCTAssert(blogPostButton.waitForHittability(timeout: 3))
-
         XCTAssert(blogPostButton.isHittable)
         blogPostButton.tap()
     }
@@ -31,6 +33,13 @@ class ActionSheetComponent: BaseScreen {
 
         XCTAssert(sitePageButton.isHittable)
         sitePageButton.tap()
+    }
+
+    func gotoStoryPost() {
+        XCTAssert(storyPostbutton.waitForExistence(timeout: 3))
+        XCTAssert(storyPostbutton.waitForHittability(timeout: 3))
+        XCTAssert(storyPostbutton.isHittable)
+        storyPostbutton.tap()
     }
 
     static func isLoaded() -> Bool {

--- a/WordPress/WordPressUITests/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorPostSettings.swift
@@ -6,6 +6,7 @@ class EditorPostSettings: BaseScreen {
     let categoriesSection: XCUIElement
     let tagsSection: XCUIElement
     let featuredImageButton: XCUIElement
+    let publishDateButton: XCUIElement
     var changeFeaturedImageButton: XCUIElement {
         return settingsTable.cells["CurrentFeaturedImage"]
     }
@@ -16,6 +17,7 @@ class EditorPostSettings: BaseScreen {
         categoriesSection = settingsTable.cells["Categories"]
         tagsSection = settingsTable.cells["Tags"]
         featuredImageButton = settingsTable.cells["SetFeaturedImage"]
+        publishDateButton = settingsTable.cells.element(boundBy: 2) // to identify "Publish Date" button on page
 
         super.init(element: settingsTable)
     }
@@ -36,6 +38,14 @@ class EditorPostSettings: BaseScreen {
         categoriesSection.tap()
 
         return CategoriesComponent()
+    }
+
+    func setSchedulledPost() -> EditorPostSettings {
+        publishDateButton.tap()
+        PublishDateComponent()
+            .setForNextThreeHours()
+            .goBackToSettings()
+        return EditorPostSettings()
     }
 
     func openTags() -> TagsComponent {

--- a/WordPress/WordPressUITests/Screens/Editor/EditorSettingsComponents/PublishDateComponent.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorSettingsComponents/PublishDateComponent.swift
@@ -1,0 +1,33 @@
+import UITestsFoundation
+import XCTest
+
+class PublishDateComponent: BaseScreen {
+    let dateAndTimeButton: XCUIElement
+    let nextButton: XCUIElement
+    let doneButton: XCUIElement
+    let postSettingsButton: XCUIElement
+    init() {
+        let app = XCUIApplication()
+        dateAndTimeButton = app.staticTexts.element(boundBy: 1) // identify element by position
+        nextButton = app.buttons["Next"]
+        doneButton = app.buttons["Done"]
+        postSettingsButton = app.buttons["Post Settings"]
+        super.init(element: postSettingsButton)
+    }
+
+    func setForNextThreeHours() -> PublishDateComponent {
+        dateAndTimeButton.tap()
+        nextButton.tap()
+        doneButton.tap()
+        return self
+    }
+
+    func goBackToSettings() -> EditorPostSettings {
+        postSettingsButton.tap()
+        return EditorPostSettings()
+    }
+
+    static func isLoaded() -> Bool {
+        return XCUIApplication().textViews["Date and Time, Immediately"].exists
+    }
+}

--- a/WordPress/WordPressUITests/Screens/Editor/SitePageSettings.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/SitePageSettings.swift
@@ -1,0 +1,9 @@
+//
+//  SitePageSettings.swift
+//  WordPressUITests
+//
+//  Created by MARIA CLARA on 17/07/21.
+//  Copyright © 2021 WordPress. All rights reserved.
+//
+
+import Foundation

--- a/WordPress/WordPressUITests/Screens/Editor/StoryPostSettings.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/StoryPostSettings.swift
@@ -1,0 +1,11 @@
+//import UITestsFoundation
+//import XCTest
+//
+//class StoryPostSettings: BaseScreen {
+//    let imagePickerIcon: XCTestCase
+//
+//    init(){
+//        let app = XCUIApplication()
+//        imagePickerIcon = app.buttons[""]
+//    }
+//}

--- a/WordPress/WordPressUITests/Screens/Media/MediaPickerAlbumListScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Media/MediaPickerAlbumListScreen.swift
@@ -15,7 +15,6 @@ class MediaPickerAlbumListScreen: BaseScreen {
         let selectedAlbum = albumList.cells.element(boundBy: index)
         XCTAssertTrue(selectedAlbum.waitForExistence(timeout: 5), "Selected album did not load")
         selectedAlbum.tap()
-
         return MediaPickerAlbumScreen()
     }
 

--- a/WordPress/WordPressUITests/Screens/SitePageScreen.swift
+++ b/WordPress/WordPressUITests/Screens/SitePageScreen.swift
@@ -1,0 +1,136 @@
+import UITestsFoundation
+import XCTest
+
+
+private struct ElementStringIDs {
+    static let closeIcon = "Close"
+    static let createBlankPageButton = "Create Blank Page"
+    static let chooseALaytoutTitle = "Choose a Layout"
+    static let blogButton = "Blog"
+    static let titleView = "Page title. Empty"
+    static let publishButton = "Publish"
+    static let moreButton = "more_post_options"
+    static let pageSettingsButton = "Page Settings"
+    static let keepEditingButton = "Keep Editing"
+    static let popUpPublishButton = "Publish"
+    static let createPageButton = "Create Page"
+    static let titleViewBlog = "Page title. Empty"
+}
+
+/// This screen object is for the Site Page section. In the app, it is where we can create a new Site Page from My Site view.
+
+class SitePageScreen: BaseScreen {
+    let closeIcon: XCUIElement
+    let createBlankPageButton: XCUIElement
+    let chooseALaytoutTitle: XCUIElement
+    let blogButton: XCUIElement
+    let selectedTemplate = XCUIApplication().cells.firstMatch
+    let createPageButton = XCUIApplication().buttons[ElementStringIDs.createPageButton]
+//    Navigation Bar
+    let publishButton = XCUIApplication().buttons[ElementStringIDs.publishButton].firstMatch
+    let keepEditingButton = XCUIApplication().buttons[ElementStringIDs.keepEditingButton]
+    let moreButton = XCUIApplication().buttons[ElementStringIDs.moreButton]
+    let pageSettingsButton = XCUIApplication().buttons[ElementStringIDs.pageSettingsButton]
+//    Editor area
+    let titleView = XCUIApplication().otherElements[ElementStringIDs.titleView].firstMatch
+    let titleViewBlog = XCUIApplication().otherElements[ElementStringIDs.titleViewBlog]
+    static var isVisible: Bool {
+        let app = XCUIApplication()
+        let createBlankPageButton = app.tables[ElementStringIDs.createBlankPageButton]
+        return createBlankPageButton.exists && createBlankPageButton.isHittable
+    }
+    // Check createBlankPageButton, closeIcon, blogButton elements to ensure Site Page is fully loaded
+    init() {
+        let app = XCUIApplication()
+        closeIcon = app.buttons[ElementStringIDs.closeIcon]
+        blogButton = app.textViews[ElementStringIDs.blogButton]
+        chooseALaytoutTitle = app.textViews[ElementStringIDs.chooseALaytoutTitle]
+        createBlankPageButton = app.buttons[ElementStringIDs.createBlankPageButton]
+        super.init(element: createBlankPageButton)
+    }
+
+    /**
+     Tap on "Create Blank Page button" to create a new blank page.
+     */
+    @discardableResult
+    func tapOnCreateBlankPageButton() -> SitePageScreen {
+        XCTAssert(createBlankPageButton.waitForExistence(timeout: 3))
+        XCTAssert(createBlankPageButton.waitForHittability(timeout: 3))
+        XCTAssert(createBlankPageButton.isHittable)
+        createBlankPageButton.tap()
+        return self
+    }
+
+    /**
+     Select the first available template to create a page from a layout.
+     */
+    func selectALayout() -> BlockEditorScreen {
+        selectedTemplate.tap()
+        XCTAssert(createPageButton.waitForExistence(timeout: 3))
+        createPageButton.tap()
+        return BlockEditorScreen()
+    }
+
+    /**
+     Tap on "Close" icon to close the activity.
+     */
+    func clickOnCloseIcon() {
+        XCTAssert(closeIcon.waitForExistence(timeout: 3))
+        XCTAssert(closeIcon.waitForHittability(timeout: 3))
+        XCTAssert(closeIcon.isHittable)
+        closeIcon.tap()
+    }
+
+    /**
+     Tap on "Publish" button to publish content.
+     */
+    func publish() -> EditorNoticeComponent {
+        XCTAssert(publishButton.waitForExistence(timeout: 3))
+        XCTAssert(publishButton.waitForHittability(timeout: 3))
+        publishButton.tap()
+        let secondPublishButton = XCUIApplication().descendants(matching: .button).containing(.button, identifier: "Publish").element(boundBy: 1)
+        secondPublishButton.tap()
+        return EditorNoticeComponent(withNotice: "Page published", andAction: "View")
+    }
+
+    /**
+     Open "Page Settings" page to custom content from EditorPostSettings.
+     */
+    func openPageSettings() -> EditorPostSettings {
+        moreButton.tap()
+        pageSettingsButton.tap()
+        return EditorPostSettings()
+    }
+
+    /**
+     Enters text into title field.
+     - Parameter text: the test to enter into the title
+     */
+    func enterTextInTitle(text: String) -> SitePageScreen {
+        if titleViewBlog.exists {
+            titleViewBlog.tap()
+            titleViewBlog.clearTextIfNeeded()
+            titleViewBlog.typeText(text)
+        } else {
+        titleView.tap()
+        titleView.typeText(text)
+        }
+        return self
+    }
+
+    /**
+     Tap on second "Publish" button, to confirm publication.
+     */
+    private func confirmPublish() {
+        if FancyAlertComponent.isLoaded() {
+            FancyAlertComponent().acceptAlert()} else {
+            XCTAssert(publishButton.waitForExistence(timeout: 3))
+            publishButton.tap()
+        }
+    }
+
+    static func isLoaded() -> Bool {
+        return
+            XCUIApplication().textViews[ElementStringIDs.chooseALaytoutTitle].exists
+    }
+}

--- a/WordPress/WordPressUITests/Screens/StoryPageScreen.swift
+++ b/WordPress/WordPressUITests/Screens/StoryPageScreen.swift
@@ -1,0 +1,58 @@
+import UITestsFoundation
+import XCTest
+
+private struct ElementStringIDs {
+    static let backButton = "Back"
+    static let createStoryPostButton = "AnnouncementsContinueButton"
+    static let mediaPickerButton = "Media Picker Button"
+    static let closeIconButton = "Close Button"
+}
+
+class StoryPageScreen: BaseScreen {
+    let backButton: XCUIElement
+    let createStoryPostButton: XCUIElement
+    let mediaPickerButton: XCUIElement
+    let closeIconButton: XCUIElement
+    static var isVisible: Bool {
+        let app = XCUIApplication()
+        let mediaPickerButton = app.buttons[ElementStringIDs.mediaPickerButton]
+        return mediaPickerButton.exists && mediaPickerButton.isHittable
+    }
+    init() {
+        let app = XCUIApplication()
+        createStoryPostButton = app.buttons[ElementStringIDs.createStoryPostButton]
+        backButton = app.buttons[ElementStringIDs.backButton]
+        mediaPickerButton = app.buttons[ElementStringIDs.mediaPickerButton]
+        closeIconButton = app.buttons[ElementStringIDs.closeIconButton]
+        super.init(element: mediaPickerButton)
+    }
+
+    func clickOnBackButton() {
+        XCTAssert(backButton.waitForExistence(timeout: 3))
+        XCTAssert(backButton.waitForHittability(timeout: 3))
+        XCTAssert(backButton.isHittable)
+        backButton.tap()
+    }
+
+    func clickOnCreateStoryPostButton() {
+        XCTAssert(createStoryPostButton.waitForExistence(timeout: 3))
+        XCTAssert(createStoryPostButton.waitForHittability(timeout: 3))
+        XCTAssert(createStoryPostButton.isHittable)
+
+        createStoryPostButton.tap()
+    }
+
+    func pickAnImageFromMedia() {
+        XCTAssert(mediaPickerButton.waitForExistence(timeout: 3))
+        XCTAssert(mediaPickerButton.waitForHittability(timeout: 3))
+        XCTAssert(mediaPickerButton.isHittable)
+        mediaPickerButton.tap()
+        MediaPickerAlbumListScreen()
+            .selectAlbum(atIndex: 0)
+            .selectImage(atIndex: 0)
+    }
+
+    static func isLoaded() -> Bool {
+        return XCUIApplication().buttons[ElementStringIDs.createStoryPostButton].exists
+    }
+}

--- a/WordPress/WordPressUITests/Screens/TabNavComponent.swift
+++ b/WordPress/WordPressUITests/Screens/TabNavComponent.swift
@@ -44,6 +44,20 @@ class TabNavComponent: BaseScreen {
         return BlockEditorScreen()
     }
 
+    func gotoStoryPostEditorScreen() -> StoryPageScreen {
+        let mySite = gotoMySiteScreen()
+        let actionSheet = mySite.gotoCreateSheet()
+        actionSheet.gotoStoryPost()
+        return StoryPageScreen()
+    }
+
+    func gotoSitePageEditorScreen() -> SitePageScreen {
+        let mySite = gotoMySiteScreen()
+        let actionSheet = mySite.gotoCreateSheet()
+        actionSheet.gotoSitePage()
+        return SitePageScreen()
+    }
+
     func gotoReaderScreen() -> ReaderScreen {
         readerTabButton.tap()
         return ReaderScreen()

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -65,6 +65,56 @@ class EditorGutenbergTests: XCTestCase {
             .done()
     }
 
+    func testNewBlogPostWithFeaturedImage() {
+        let title = getRandomPhrase()
+        let content = getRandomContent()
+        editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .enterTextInTitle(text: title)
+            .addParagraphBlock(withText: content)
+            .openPostSettings()
+            .setFeaturedImage()
+            .verifyPostSettings(hasImage: true)
+            .closePostSettings()
+        BlockEditorScreen().publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+
+    }
+
+    func testNewBlogPostWithDifferentMediaTypes() {
+        let title = getRandomPhrase()
+        editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .enterTextInTitle(text: title)
+            .openBlockPicker()
+            .addImage()
+            .openBlockPicker()
+            .addVideo()
+            .publish()
+            .viewPublishedPost(withTitle: title)
+//            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+
+    func testNewBlogPostSchedulled() {
+        let title = getRandomPhrase()
+        editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .enterTextInTitle(text: title)
+            .openPostSettings()
+            .setSchedulledPost()
+            .closePostSettings()
+        BlockEditorScreen().schedule()
+            .viewPublishedPost(withTitle: title)
+    }
+
+    func testCreateNewPageFromMultiuserAndChangeTheAuthor() {
+        editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+    }
+
     func skipTillBloggingRemindersAreHandled(file: StaticString = #file, line: UInt = #line) throws {
         try XCTSkipIf(true, "Skipping test because we haven't added support for Blogging Reminders. See https://github.com/wordpress-mobile/WordPress-iOS/issues/16797.", file: file, line: line)
     }

--- a/WordPress/WordPressUITests/Tests/SitePageTests.swift
+++ b/WordPress/WordPressUITests/Tests/SitePageTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+class SitePageTests: XCTestCase {
+    private var sitePageEditorScreen: SitePageScreen!
+    override func setUp() {
+        setUpTestSuite()
+        _ = LoginFlow.loginIfNeeded (siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        sitePageEditorScreen = EditorFlow.gotoMySiteScreen()
+            .tabBar.gotoSitePageEditorScreen()
+    }
+
+    func testCreateNewPageFromLayout() {
+        let title = getRandomPhrase()
+        sitePageEditorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .selectALayout()
+            .enterTextInTitle(text: title)
+            .publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+
+    func testCreateNewBlankPage() {
+        let title = getRandomPhrase()
+        sitePageEditorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .tapOnCreateBlankPageButton()
+            .enterTextInTitle(text: title)
+            .publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+
+    func testCreateNewPageWithFeaturedImage() {
+        let title = getRandomPhrase()
+        sitePageEditorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .tapOnCreateBlankPageButton()
+            .enterTextInTitle(text: title)
+            .openPageSettings()
+            .setFeaturedImage()
+            .verifyPostSettings(hasImage: true)
+            .closePostSettings()
+        BlockEditorScreen().publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+}

--- a/WordPress/WordPressUITests/Tests/StoryPageTests.swift
+++ b/WordPress/WordPressUITests/Tests/StoryPageTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+class StoryPageTests: XCTestCase {
+    private var storyPostEditorScreen: StoryPageScreen!
+    override func setUp() {
+        setUpTestSuite()
+        _ = LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        storyPostEditorScreen = EditorFlow.gotoMySiteScreen()
+            .tabBar.gotoStoryPostEditorScreen()
+    }
+
+    func testCreateAStoryUsingPhotos() {
+        storyPostEditorScreen
+            .pickAnImageFromMedia()
+    }
+}


### PR DESCRIPTION
Site Page related changes:
- New TC "Create new page from layout" on "SitePageTests.swift"
- New TC "Create new page from blank page" on "SitePageTests.swift"
- New TC "Add a featured image" on "SitePageTests.swift"
- New page controller on "SitePageScreen.swift"
- New functions for Site Page on "SitePageSettings.swift"

Blog Posts related changes:
- New TC "Create a scheduled post" on "EditorGutenbergTests.swift"
- New TC "Add featured image" on "EditorGutenbergTests.swift"
- New TC "Insert different content media type from within the editor and post" on "EditorGutenbergTests.swift"
- New functions on "BlockEditorScreen.swift" and "EditorPostSettings.swift"

Story Page related changes:
- Started (not completed) new TC "Create a story" on "StoryPageTests.swift"
- Call to activity page on "TabNavComponent.swift"
- New page controller on "StoryPageScreen.swift"
- New functions for Story Page on "StoryPageScreen.swift"

Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
