### PR TITLE
Trial maria clara

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2009,6 +2009,7 @@
 		CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBD3EAA0FF1BA3B00C1396E /* Blog.m */; };
 		D40F1B0426B0CC22000306F7 /* PublishDateComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0326B0CC21000306F7 /* PublishDateComponent.swift */; };
 		D40F1B0626B0CD39000306F7 /* SitePageScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */; };
+		D40F1B0826B0D38C000306F7 /* StoryPageScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0726B0D38C000306F7 /* StoryPageScreen.swift */; };
 		D8071631203DA23700B32FD9 /* Accessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8071630203DA23700B32FD9 /* Accessible.swift */; };
 		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
 		D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */; };
@@ -6686,6 +6687,7 @@
 		D1216A69ECC61E7772AB8C41 /* Pods-WordPressThisWeekWidget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressThisWeekWidget.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressThisWeekWidget/Pods-WordPressThisWeekWidget.debug.xcconfig"; sourceTree = "<group>"; };
 		D40F1B0326B0CC21000306F7 /* PublishDateComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishDateComponent.swift; sourceTree = "<group>"; };
 		D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePageScreen.swift; sourceTree = "<group>"; };
+		D40F1B0726B0D38C000306F7 /* StoryPageScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryPageScreen.swift; sourceTree = "<group>"; };
 		D61CEAC1CB25AE65B26BDC68 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		D67306CD28F2440FF6B0065C /* Pods-WordPressIntents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressIntents.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressIntents/Pods-WordPressIntents.debug.xcconfig"; sourceTree = "<group>"; };
 		D8071630203DA23700B32FD9 /* Accessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessible.swift; sourceTree = "<group>"; };
@@ -12848,6 +12850,7 @@
 				CC94FC67221452A4002E5825 /* EditorNoticeComponent.swift */,
 				CC19BE05223FECAC00CAB3E1 /* EditorPostSettings.swift */,
 				FFD47BDE2474228C00F00660 /* FeaturedImageScreen.swift */,
+				D40F1B0726B0D38C000306F7 /* StoryPageScreen.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -20258,6 +20261,7 @@
 				CC7CB97622B15A2900642EE9 /* SignupEmailScreen.swift in Sources */,
 				D40F1B0626B0CD39000306F7 /* SitePageScreen.swift in Sources */,
 				CCE911BE221D85E4007E1D4E /* LoginUsernamePasswordScreen.swift in Sources */,
+				D40F1B0826B0D38C000306F7 /* StoryPageScreen.swift in Sources */,
 				FA41070E263957C000E90EBF /* JetpackBackupOptionsScreen.swift in Sources */,
 				BE6DD32E1FD67EDA00E55192 /* MySitesScreen.swift in Sources */,
 				BED4D8351FF1208400A11345 /* AztecEditorScreen.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2011,6 +2011,7 @@
 		D40F1B0626B0CD39000306F7 /* SitePageScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */; };
 		D40F1B0826B0D38C000306F7 /* StoryPageScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0726B0D38C000306F7 /* StoryPageScreen.swift */; };
 		D40F1B0A26B0D6D2000306F7 /* SitePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0926B0D6D2000306F7 /* SitePageTests.swift */; };
+		D40F1B0C26B0D756000306F7 /* StoryPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0B26B0D756000306F7 /* StoryPageTests.swift */; };
 		D8071631203DA23700B32FD9 /* Accessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8071630203DA23700B32FD9 /* Accessible.swift */; };
 		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
 		D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */; };
@@ -6690,6 +6691,7 @@
 		D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePageScreen.swift; sourceTree = "<group>"; };
 		D40F1B0726B0D38C000306F7 /* StoryPageScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryPageScreen.swift; sourceTree = "<group>"; };
 		D40F1B0926B0D6D2000306F7 /* SitePageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePageTests.swift; sourceTree = "<group>"; };
+		D40F1B0B26B0D756000306F7 /* StoryPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryPageTests.swift; sourceTree = "<group>"; };
 		D61CEAC1CB25AE65B26BDC68 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		D67306CD28F2440FF6B0065C /* Pods-WordPressIntents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressIntents.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressIntents/Pods-WordPressIntents.debug.xcconfig"; sourceTree = "<group>"; };
 		D8071630203DA23700B32FD9 /* Accessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessible.swift; sourceTree = "<group>"; };
@@ -12818,6 +12820,7 @@
 				BED4D82F1FF11DEF00A11345 /* EditorAztecTests.swift */,
 				CC2BB0CF228ACF710034F9AB /* EditorGutenbergTests.swift */,
 				D40F1B0926B0D6D2000306F7 /* SitePageTests.swift */,
+				D40F1B0B26B0D756000306F7 /* StoryPageTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -20264,6 +20267,7 @@
 				CC7CB97622B15A2900642EE9 /* SignupEmailScreen.swift in Sources */,
 				D40F1B0626B0CD39000306F7 /* SitePageScreen.swift in Sources */,
 				CCE911BE221D85E4007E1D4E /* LoginUsernamePasswordScreen.swift in Sources */,
+				D40F1B0C26B0D756000306F7 /* StoryPageTests.swift in Sources */,
 				D40F1B0826B0D38C000306F7 /* StoryPageScreen.swift in Sources */,
 				FA41070E263957C000E90EBF /* JetpackBackupOptionsScreen.swift in Sources */,
 				BE6DD32E1FD67EDA00E55192 /* MySitesScreen.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2010,6 +2010,7 @@
 		D40F1B0426B0CC22000306F7 /* PublishDateComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0326B0CC21000306F7 /* PublishDateComponent.swift */; };
 		D40F1B0626B0CD39000306F7 /* SitePageScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */; };
 		D40F1B0826B0D38C000306F7 /* StoryPageScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0726B0D38C000306F7 /* StoryPageScreen.swift */; };
+		D40F1B0A26B0D6D2000306F7 /* SitePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0926B0D6D2000306F7 /* SitePageTests.swift */; };
 		D8071631203DA23700B32FD9 /* Accessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8071630203DA23700B32FD9 /* Accessible.swift */; };
 		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
 		D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */; };
@@ -6688,6 +6689,7 @@
 		D40F1B0326B0CC21000306F7 /* PublishDateComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishDateComponent.swift; sourceTree = "<group>"; };
 		D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePageScreen.swift; sourceTree = "<group>"; };
 		D40F1B0726B0D38C000306F7 /* StoryPageScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryPageScreen.swift; sourceTree = "<group>"; };
+		D40F1B0926B0D6D2000306F7 /* SitePageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePageTests.swift; sourceTree = "<group>"; };
 		D61CEAC1CB25AE65B26BDC68 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		D67306CD28F2440FF6B0065C /* Pods-WordPressIntents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressIntents.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressIntents/Pods-WordPressIntents.debug.xcconfig"; sourceTree = "<group>"; };
 		D8071630203DA23700B32FD9 /* Accessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessible.swift; sourceTree = "<group>"; };
@@ -12815,6 +12817,7 @@
 				FFA0B7D61CAC1F9F00533B9D /* MainNavigationTests.swift */,
 				BED4D82F1FF11DEF00A11345 /* EditorAztecTests.swift */,
 				CC2BB0CF228ACF710034F9AB /* EditorGutenbergTests.swift */,
+				D40F1B0926B0D6D2000306F7 /* SitePageTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -20269,6 +20272,7 @@
 				FA41044D263932AC00E90EBF /* ActivityLogScreen.swift in Sources */,
 				BE87071B2006E65C004FB5A4 /* NotificationsScreen.swift in Sources */,
 				BE6DD3321FD6803700E55192 /* MeTabScreen.swift in Sources */,
+				D40F1B0A26B0D6D2000306F7 /* SitePageTests.swift in Sources */,
 				BED4D8301FF11DEF00A11345 /* EditorAztecTests.swift in Sources */,
 				BE8707172006B774004FB5A4 /* MySiteScreen.swift in Sources */,
 				CCE55E992242715C002A9634 /* CategoriesComponent.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2007,6 +2007,8 @@
 		CE39E17320CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39E17120CB117B00CABA05 /* RemoteBlog+Capabilities.swift */; };
 		CE46018B21139E8300F242B6 /* FooterTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE46018A21139E8300F242B6 /* FooterTextContent.swift */; };
 		CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBD3EAA0FF1BA3B00C1396E /* Blog.m */; };
+		D40F1B0426B0CC22000306F7 /* PublishDateComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0326B0CC21000306F7 /* PublishDateComponent.swift */; };
+		D40F1B0626B0CD39000306F7 /* SitePageScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */; };
 		D8071631203DA23700B32FD9 /* Accessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8071630203DA23700B32FD9 /* Accessible.swift */; };
 		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
 		D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */; };
@@ -6682,6 +6684,8 @@
 		CEBD3EAA0FF1BA3B00C1396E /* Blog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Blog.m; sourceTree = "<group>"; };
 		CF343E897B9953453334768C /* Pods-WordPressHomeWidgetToday.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressHomeWidgetToday.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressHomeWidgetToday/Pods-WordPressHomeWidgetToday.release.xcconfig"; sourceTree = "<group>"; };
 		D1216A69ECC61E7772AB8C41 /* Pods-WordPressThisWeekWidget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressThisWeekWidget.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressThisWeekWidget/Pods-WordPressThisWeekWidget.debug.xcconfig"; sourceTree = "<group>"; };
+		D40F1B0326B0CC21000306F7 /* PublishDateComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishDateComponent.swift; sourceTree = "<group>"; };
+		D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePageScreen.swift; sourceTree = "<group>"; };
 		D61CEAC1CB25AE65B26BDC68 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		D67306CD28F2440FF6B0065C /* Pods-WordPressIntents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressIntents.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressIntents/Pods-WordPressIntents.debug.xcconfig"; sourceTree = "<group>"; };
 		D8071630203DA23700B32FD9 /* Accessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessible.swift; sourceTree = "<group>"; };
@@ -12755,6 +12759,7 @@
 				FA4104732639393700E90EBF /* JetpackScanScreen.swift */,
 				FA4104BE26393F1A00E90EBF /* JetpackBackupScreen.swift */,
 				FA41070D263957C000E90EBF /* JetpackBackupOptionsScreen.swift */,
+				D40F1B0526B0CD39000306F7 /* SitePageScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -13108,6 +13113,7 @@
 			children = (
 				CCE55E982242715C002A9634 /* CategoriesComponent.swift */,
 				CC8498D22241477F00DB490A /* TagsComponent.swift */,
+				D40F1B0326B0CC21000306F7 /* PublishDateComponent.swift */,
 			);
 			path = EditorSettingsComponents;
 			sourceTree = "<group>";
@@ -20250,6 +20256,7 @@
 				CC19BE06223FECAC00CAB3E1 /* EditorPostSettings.swift in Sources */,
 				FFA0B7D71CAC1F9F00533B9D /* MainNavigationTests.swift in Sources */,
 				CC7CB97622B15A2900642EE9 /* SignupEmailScreen.swift in Sources */,
+				D40F1B0626B0CD39000306F7 /* SitePageScreen.swift in Sources */,
 				CCE911BE221D85E4007E1D4E /* LoginUsernamePasswordScreen.swift in Sources */,
 				FA41070E263957C000E90EBF /* JetpackBackupOptionsScreen.swift in Sources */,
 				BE6DD32E1FD67EDA00E55192 /* MySitesScreen.swift in Sources */,
@@ -20269,6 +20276,7 @@
 				FFD47BDF2474228C00F00660 /* FeaturedImageScreen.swift in Sources */,
 				BE2B4E9F1FD664F5007AE3E4 /* BaseScreen.swift in Sources */,
 				98AA22BF25082B1E005CCC13 /* GetStartedScreen.swift in Sources */,
+				D40F1B0426B0CC22000306F7 /* PublishDateComponent.swift in Sources */,
 				CC7CB97A22B15C1000642EE9 /* SignupEpilogueScreen.swift in Sources */,
 				F5E032EC240D49FF003AF350 /* ActionSheetComponent.swift in Sources */,
 				BE6DD32A1FD6708900E55192 /* LinkOrPasswordScreen.swift in Sources */,

--- a/WordPress/WordPressUITests/Screens/ActionSheetComponent.swift
+++ b/WordPress/WordPressUITests/Screens/ActionSheetComponent.swift
@@ -2,15 +2,18 @@ import UITestsFoundation
 import XCTest
 
 class ActionSheetComponent: BaseScreen {
+    let storyPostbutton: XCUIElement
     let blogPostButton: XCUIElement
     let sitePageButton: XCUIElement
 
     struct ElementIDs {
+        static let storyPostButton = "storyButton"
         static let blogPostButton = "blogPostButton"
         static let sitePageButton = "sitePageButton"
     }
 
     init() {
+        storyPostbutton = XCUIApplication().buttons[ElementIDs.storyPostButton]
         blogPostButton = XCUIApplication().buttons[ElementIDs.blogPostButton]
         sitePageButton = XCUIApplication().buttons[ElementIDs.sitePageButton]
 
@@ -32,6 +35,13 @@ class ActionSheetComponent: BaseScreen {
         XCTAssert(sitePageButton.isHittable)
         sitePageButton.tap()
     }
+
+    func gotoStoryPost() {
+            XCTAssert(storyPostbutton.waitForExistence(timeout: 3))
+            XCTAssert(storyPostbutton.waitForHittability(timeout: 3))
+            XCTAssert(storyPostbutton.isHittable)
+            storyPostbutton.tap()
+        }
 
     static func isLoaded() -> Bool {
         return XCUIApplication().buttons[ElementIDs.blogPostButton].waitForExistence(timeout: 3)

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -71,7 +71,7 @@ class BlockEditorScreen: BaseScreen {
      Adds an image block with latest image from device.
      */
     func addImage() -> BlockEditorScreen {
-        addBlock("Image block")
+        addImageBlockMenu.tap()
         addImageByOrder(id: 0)
 
         return self

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -8,11 +8,14 @@ class BlockEditorScreen: BaseScreen {
     let editorCloseButton = XCUIApplication().navigationBars["Gutenberg Editor Navigation Bar"].buttons["Close"]
     let publishButton = XCUIApplication().buttons["Publish"]
     let publishNowButton = XCUIApplication().buttons["Publish Now"]
+    let scheduleButton = XCUIApplication().buttons["Schedule"]
+    let scheduleNowButton = XCUIApplication().buttons["Schedule Now"]
     let moreButton = XCUIApplication().buttons["more_post_options"]
 
     // Editor area
     // Title
     let titleView = XCUIApplication().otherElements["Post title. Empty"].firstMatch // Uses a localized string
+    let titleViewBlog = XCUIApplication().otherElements["Page title. Blog"].firstMatch
     // Paragraph block
     let paragraphView = XCUIApplication().otherElements["Paragraph Block. Row 1. Empty"].textViews.element(boundBy: 0)
     // Image block
@@ -20,10 +23,15 @@ class BlockEditorScreen: BaseScreen {
 
     // Toolbar
     let addBlockButton = XCUIApplication().buttons["add-block-button"] // Uses a testID
+    let addImageBlockMenu =  XCUIApplication().buttons["Image block"]
+    let addVideoBlockMenu = XCUIApplication().buttons["Video block"]
+    let editImageButton = XCUIApplication().buttons["Edit image"]
+    let publishDateButton = XCUIApplication().buttons["Publish Date, Immediately"]
 
     // Action sheets
     let actionSheet = XCUIApplication().sheets.element(boundBy: 0)
     let imageDeviceButton = XCUIApplication().sheets.buttons["Choose from device"] // Uses a localized string
+    let wordPressMediaLibraryButton = XCUIApplication().sheets.buttons["WordPress Media Library"]
     let discardButton = XCUIApplication().buttons["Discard"] // Uses a localized string
     let postSettingsButton = XCUIApplication().sheets.buttons["Post Settings"] // Uses a localized string
     let keepEditingButton = XCUIApplication().sheets.buttons["Keep Editing"] // Uses a localized string
@@ -38,8 +46,12 @@ class BlockEditorScreen: BaseScreen {
      - Parameter text: the test to enter into the title
      */
     func enterTextInTitle(text: String) -> BlockEditorScreen {
+        if titleViewBlog.waitForExistence(timeout: 5) {
+            titleViewBlog.doubleTap()
+            titleViewBlog.typeText(text)
+        } else {
         titleView.tap()
-        titleView.typeText(text)
+        titleView.typeText(text)}
 
         return self
     }
@@ -65,6 +77,12 @@ class BlockEditorScreen: BaseScreen {
         return self
     }
 
+    @discardableResult
+    func addVideo() -> BlockEditorScreen {
+        addVideoBlockMenu.tap()
+        addVideoByOrder(id: 0)
+        return self
+    }
     /**
     Selects a block based on part of the block label (e.g. partial text in a paragraph block)
      */
@@ -107,9 +125,23 @@ class BlockEditorScreen: BaseScreen {
 
     func publish() -> EditorNoticeComponent {
         publishButton.tap()
-        confirmPublish()
+        var withNoticeContent = "Post published"
+        if publishNowButton.waitForExistence(timeout: 5) {
+            confirmPublish()
+        } else {
+        withNoticeContent = "Page published"
+        let secondPublishButton = XCUIApplication().descendants(matching: .button).containing(.button, identifier: "Publish").element(boundBy: 1)
+            secondPublishButton.tap()
+        }
+        return EditorNoticeComponent(withNotice: withNoticeContent, andAction: "View")
+    }
 
-        return EditorNoticeComponent(withNotice: "Post published", andAction: "View")
+    func schedule() -> EditorNoticeComponent {
+        let withNoticeContent = "Post updated"
+        scheduleButton.tap()
+        scheduleNowButton.waitForExistence(timeout: 3)
+        scheduleNowButton.tap()
+        return EditorNoticeComponent(withNotice: withNoticeContent, andAction: "View")
     }
 
     func openPostSettings() -> EditorPostSettings {
@@ -136,6 +168,12 @@ class BlockEditorScreen: BaseScreen {
         // Inject the first picture
         MediaPickerAlbumListScreen()
             .selectAlbum(atIndex: 0)
+            .selectImage(atIndex: 0)
+    }
+
+    private func addVideoByOrder(id: Int) {
+        wordPressMediaLibraryButton.tap()
+        MediaPickerAlbumScreen()
             .selectImage(atIndex: 0)
     }
 

--- a/WordPress/WordPressUITests/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorPostSettings.swift
@@ -6,6 +6,7 @@ class EditorPostSettings: BaseScreen {
     let categoriesSection: XCUIElement
     let tagsSection: XCUIElement
     let featuredImageButton: XCUIElement
+    let publishDateButton: XCUIElement
     var changeFeaturedImageButton: XCUIElement {
         return settingsTable.cells["CurrentFeaturedImage"]
     }
@@ -16,6 +17,7 @@ class EditorPostSettings: BaseScreen {
         categoriesSection = settingsTable.cells["Categories"]
         tagsSection = settingsTable.cells["Tags"]
         featuredImageButton = settingsTable.cells["SetFeaturedImage"]
+        publishDateButton = settingsTable.cells.element(boundBy: 2) // to identify "Publish Date" button on page
 
         super.init(element: settingsTable)
     }
@@ -37,6 +39,14 @@ class EditorPostSettings: BaseScreen {
 
         return CategoriesComponent()
     }
+    
+    func setSchedulledPost() -> EditorPostSettings {
+            publishDateButton.tap()
+            PublishDateComponent()
+                .setForNextThreeHours()
+                .goBackToSettings()
+            return EditorPostSettings()
+        }
 
     func openTags() -> TagsComponent {
         tagsSection.tap()

--- a/WordPress/WordPressUITests/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorPostSettings.swift
@@ -39,7 +39,7 @@ class EditorPostSettings: BaseScreen {
 
         return CategoriesComponent()
     }
-    
+
     func setSchedulledPost() -> EditorPostSettings {
             publishDateButton.tap()
             PublishDateComponent()

--- a/WordPress/WordPressUITests/Screens/Editor/EditorSettingsComponents/PublishDateComponent.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorSettingsComponents/PublishDateComponent.swift
@@ -1,0 +1,33 @@
+import UITestsFoundation
+import XCTest
+
+class PublishDateComponent: BaseScreen {
+    let dateAndTimeButton: XCUIElement
+    let nextButton: XCUIElement
+    let doneButton: XCUIElement
+    let postSettingsButton: XCUIElement
+    init() {
+        let app = XCUIApplication()
+        dateAndTimeButton = app.staticTexts.element(boundBy: 1) // identify element by position
+        nextButton = app.buttons["Next"]
+        doneButton = app.buttons["Done"]
+        postSettingsButton = app.buttons["Post Settings"]
+        super.init(element: postSettingsButton)
+    }
+
+    func setForNextThreeHours() -> PublishDateComponent {
+        dateAndTimeButton.tap()
+        nextButton.tap()
+        doneButton.tap()
+        return self
+    }
+
+    func goBackToSettings() -> EditorPostSettings {
+        postSettingsButton.tap()
+        return EditorPostSettings()
+    }
+
+    static func isLoaded() -> Bool {
+        return XCUIApplication().textViews["Date and Time, Immediately"].exists
+    }
+}

--- a/WordPress/WordPressUITests/Screens/Editor/StoryPageScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/StoryPageScreen.swift
@@ -1,0 +1,58 @@
+import UITestsFoundation
+import XCTest
+
+private struct ElementStringIDs {
+    static let backButton = "Back"
+    static let createStoryPostButton = "AnnouncementsContinueButton"
+    static let mediaPickerButton = "Media Picker Button"
+    static let closeIconButton = "Close Button"
+}
+
+class StoryPageScreen: BaseScreen {
+    let backButton: XCUIElement
+    let createStoryPostButton: XCUIElement
+    let mediaPickerButton: XCUIElement
+    let closeIconButton: XCUIElement
+    static var isVisible: Bool {
+        let app = XCUIApplication()
+        let mediaPickerButton = app.buttons[ElementStringIDs.mediaPickerButton]
+        return mediaPickerButton.exists && mediaPickerButton.isHittable
+    }
+    init() {
+        let app = XCUIApplication()
+        createStoryPostButton = app.buttons[ElementStringIDs.createStoryPostButton]
+        backButton = app.buttons[ElementStringIDs.backButton]
+        mediaPickerButton = app.buttons[ElementStringIDs.mediaPickerButton]
+        closeIconButton = app.buttons[ElementStringIDs.closeIconButton]
+        super.init(element: mediaPickerButton)
+    }
+
+    func clickOnBackButton() {
+        XCTAssert(backButton.waitForExistence(timeout: 3))
+        XCTAssert(backButton.waitForHittability(timeout: 3))
+        XCTAssert(backButton.isHittable)
+        backButton.tap()
+    }
+
+    func clickOnCreateStoryPostButton() {
+        XCTAssert(createStoryPostButton.waitForExistence(timeout: 3))
+        XCTAssert(createStoryPostButton.waitForHittability(timeout: 3))
+        XCTAssert(createStoryPostButton.isHittable)
+
+        createStoryPostButton.tap()
+    }
+
+    func pickAnImageFromMedia() {
+        XCTAssert(mediaPickerButton.waitForExistence(timeout: 3))
+        XCTAssert(mediaPickerButton.waitForHittability(timeout: 3))
+        XCTAssert(mediaPickerButton.isHittable)
+        mediaPickerButton.tap()
+        MediaPickerAlbumListScreen()
+            .selectAlbum(atIndex: 0)
+            .selectImage(atIndex: 0)
+    }
+
+    static func isLoaded() -> Bool {
+        return XCUIApplication().buttons[ElementStringIDs.createStoryPostButton].exists
+    }
+}

--- a/WordPress/WordPressUITests/Screens/SitePageScreen.swift
+++ b/WordPress/WordPressUITests/Screens/SitePageScreen.swift
@@ -1,0 +1,135 @@
+import UITestsFoundation
+import XCTest
+
+
+private struct ElementStringIDs {
+    static let closeIcon = "Close"
+    static let createBlankPageButton = "Create Blank Page"
+    static let chooseALaytoutTitle = "Choose a Layout"
+    static let blogButton = "Blog"
+    static let titleView = "Page title. Empty"
+    static let publishButton = "Publish"
+    static let moreButton = "more_post_options"
+    static let pageSettingsButton = "Page Settings"
+    static let keepEditingButton = "Keep Editing"
+    static let popUpPublishButton = "Publish"
+    static let createPageButton = "Create Page"
+    static let titleViewBlog = "Page title. Empty"
+}
+
+/// This screen object is for the Site Page section. In the app, it is where we can create a new Site Page from My Site view.
+class SitePageScreen: BaseScreen {
+    let closeIcon: XCUIElement
+    let createBlankPageButton: XCUIElement
+    let chooseALaytoutTitle: XCUIElement
+    let blogButton: XCUIElement
+    let selectedTemplate = XCUIApplication().cells.firstMatch
+    let createPageButton = XCUIApplication().buttons[ElementStringIDs.createPageButton]
+//    Navigation Bar
+    let publishButton = XCUIApplication().buttons[ElementStringIDs.publishButton].firstMatch
+    let keepEditingButton = XCUIApplication().buttons[ElementStringIDs.keepEditingButton]
+    let moreButton = XCUIApplication().buttons[ElementStringIDs.moreButton]
+    let pageSettingsButton = XCUIApplication().buttons[ElementStringIDs.pageSettingsButton]
+//    Editor area
+    let titleView = XCUIApplication().otherElements[ElementStringIDs.titleView].firstMatch
+    let titleViewBlog = XCUIApplication().otherElements[ElementStringIDs.titleViewBlog]
+    static var isVisible: Bool {
+        let app = XCUIApplication()
+        let createBlankPageButton = app.tables[ElementStringIDs.createBlankPageButton]
+        return createBlankPageButton.exists && createBlankPageButton.isHittable
+    }
+    // Check createBlankPageButton, closeIcon, blogButton elements to ensure Site Page is fully loaded
+    init() {
+        let app = XCUIApplication()
+        closeIcon = app.buttons[ElementStringIDs.closeIcon]
+        blogButton = app.textViews[ElementStringIDs.blogButton]
+        chooseALaytoutTitle = app.textViews[ElementStringIDs.chooseALaytoutTitle]
+        createBlankPageButton = app.buttons[ElementStringIDs.createBlankPageButton]
+        super.init(element: createBlankPageButton)
+    }
+
+    /**
+     Tap on "Create Blank Page button" to create a new blank page.
+     */
+    @discardableResult
+    func tapOnCreateBlankPageButton() -> SitePageScreen {
+        XCTAssert(createBlankPageButton.waitForExistence(timeout: 3))
+        XCTAssert(createBlankPageButton.waitForHittability(timeout: 3))
+        XCTAssert(createBlankPageButton.isHittable)
+        createBlankPageButton.tap()
+        return self
+    }
+
+    /**
+     Select the first available template to create a page from a layout.
+     */
+    func selectALayout() -> BlockEditorScreen {
+        selectedTemplate.tap()
+        XCTAssert(createPageButton.waitForExistence(timeout: 3))
+        createPageButton.tap()
+        return BlockEditorScreen()
+    }
+
+    /**
+     Tap on "Close" icon to close the activity.
+     */
+    func clickOnCloseIcon() {
+        XCTAssert(closeIcon.waitForExistence(timeout: 3))
+        XCTAssert(closeIcon.waitForHittability(timeout: 3))
+        XCTAssert(closeIcon.isHittable)
+        closeIcon.tap()
+    }
+
+    /**
+     Tap on "Publish" button to publish content.
+     */
+    func publish() -> EditorNoticeComponent {
+        XCTAssert(publishButton.waitForExistence(timeout: 3))
+        XCTAssert(publishButton.waitForHittability(timeout: 3))
+        publishButton.tap()
+        let secondPublishButton = XCUIApplication().descendants(matching: .button).containing(.button, identifier: "Publish").element(boundBy: 1)
+        secondPublishButton.tap()
+        return EditorNoticeComponent(withNotice: "Page published", andAction: "View")
+    }
+
+    /**
+     Open "Page Settings" page to custom content from EditorPostSettings.
+     */
+    func openPageSettings() -> EditorPostSettings {
+        moreButton.tap()
+        pageSettingsButton.tap()
+        return EditorPostSettings()
+    }
+
+    /**
+     Enters text into title field.
+     - Parameter text: the test to enter into the title
+     */
+    func enterTextInTitle(text: String) -> SitePageScreen {
+        if titleViewBlog.exists {
+            titleViewBlog.tap()
+            titleViewBlog.clearTextIfNeeded()
+            titleViewBlog.typeText(text)
+        } else {
+        titleView.tap()
+        titleView.typeText(text)
+        }
+        return self
+    }
+
+    /**
+     Tap on second "Publish" button, to confirm publication.
+     */
+    private func confirmPublish() {
+        if FancyAlertComponent.isLoaded() {
+            FancyAlertComponent().acceptAlert()} else {
+            XCTAssert(publishButton.waitForExistence(timeout: 3))
+            publishButton.tap()
+        }
+    }
+
+    static func isLoaded() -> Bool {
+        return
+            XCUIApplication().textViews[ElementStringIDs.chooseALaytoutTitle].exists
+    }
+}

--- a/WordPress/WordPressUITests/Screens/TabNavComponent.swift
+++ b/WordPress/WordPressUITests/Screens/TabNavComponent.swift
@@ -44,6 +44,20 @@ class TabNavComponent: BaseScreen {
         return BlockEditorScreen()
     }
 
+    func gotoStoryPostEditorScreen() -> StoryPageScreen {
+        let mySite = gotoMySiteScreen()
+        let actionSheet = mySite.gotoCreateSheet()
+        actionSheet.gotoStoryPost()
+        return StoryPageScreen()
+    }
+
+    func gotoSitePageEditorScreen() -> SitePageScreen {
+        let mySite = gotoMySiteScreen()
+        let actionSheet = mySite.gotoCreateSheet()
+        actionSheet.gotoSitePage()
+        return SitePageScreen()
+    }
+
     func gotoReaderScreen() -> ReaderScreen {
         readerTabButton.tap()
         return ReaderScreen()

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -65,6 +65,57 @@ class EditorGutenbergTests: XCTestCase {
             .done()
     }
 
+    func testNewBlogPostWithFeaturedImage() {
+        let title = getRandomPhrase()
+        let content = getRandomContent()
+        editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .enterTextInTitle(text: title)
+            .addParagraphBlock(withText: content)
+            .openPostSettings()
+            .setFeaturedImage()
+            .verifyPostSettings(hasImage: true)
+            .closePostSettings()
+        BlockEditorScreen().publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+
+    }
+
+    func testNewBlogPostWithDifferentMediaTypes() {
+        let title = getRandomPhrase()
+        editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .enterTextInTitle(text: title)
+            .openBlockPicker()
+            .addImage()
+            .openBlockPicker()
+            .addVideo()
+            .publish()
+            .viewPublishedPost(withTitle: title)
+//            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+
+    func testNewBlogPostSchedulled() {
+        let title = getRandomPhrase()
+        editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .enterTextInTitle(text: title)
+            .openPostSettings()
+            .setSchedulledPost()
+            .closePostSettings()
+        BlockEditorScreen().schedule()
+            .viewPublishedPost(withTitle: title)
+    }
+
+    func testCreateNewPageFromMultiuserAndChangeTheAuthor() {
+        editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+    }
+
+
     func skipTillBloggingRemindersAreHandled(file: StaticString = #file, line: UInt = #line) throws {
         try XCTSkipIf(true, "Skipping test because we haven't added support for Blogging Reminders. See https://github.com/wordpress-mobile/WordPress-iOS/issues/16797.", file: file, line: line)
     }

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -12,15 +12,15 @@ class EditorGutenbergTests: XCTestCase {
             .tabBar.gotoBlockEditorScreen()
     }
 
-    override func tearDown() {
-        takeScreenshotOfFailedTest()
-        if editorScreen != nil && !TabNavComponent.isVisible() {
-            EditorFlow.returnToMainEditorScreen()
-            editorScreen.closeEditor()
-        }
-        LoginFlow.logoutIfNeeded()
-        super.tearDown()
-    }
+//    override func tearDown() {
+//        takeScreenshotOfFailedTest()
+//        if editorScreen != nil && !TabNavComponent.isVisible() {
+//            EditorFlow.returnToMainEditorScreen()
+//            editorScreen.closeEditor()
+//        }
+//        LoginFlow.logoutIfNeeded()
+//        super.tearDown()
+//    }
 
     func testTextPostPublish() throws {
         try skipTillBloggingRemindersAreHandled()
@@ -94,7 +94,6 @@ class EditorGutenbergTests: XCTestCase {
             .addVideo()
             .publish()
             .viewPublishedPost(withTitle: title)
-//            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .done()
     }
 
@@ -108,13 +107,8 @@ class EditorGutenbergTests: XCTestCase {
             .closePostSettings()
         BlockEditorScreen().schedule()
             .viewPublishedPost(withTitle: title)
+            .done()
     }
-
-    func testCreateNewPageFromMultiuserAndChangeTheAuthor() {
-        editorScreen
-            .dismissNotificationAlertIfNeeded(.accept)
-    }
-
 
     func skipTillBloggingRemindersAreHandled(file: StaticString = #file, line: UInt = #line) throws {
         try XCTSkipIf(true, "Skipping test because we haven't added support for Blogging Reminders. See https://github.com/wordpress-mobile/WordPress-iOS/issues/16797.", file: file, line: line)

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -12,15 +12,15 @@ class EditorGutenbergTests: XCTestCase {
             .tabBar.gotoBlockEditorScreen()
     }
 
-//    override func tearDown() {
-//        takeScreenshotOfFailedTest()
-//        if editorScreen != nil && !TabNavComponent.isVisible() {
-//            EditorFlow.returnToMainEditorScreen()
-//            editorScreen.closeEditor()
-//        }
-//        LoginFlow.logoutIfNeeded()
-//        super.tearDown()
-//    }
+    override func tearDown() {
+        takeScreenshotOfFailedTest()
+        if editorScreen != nil && !TabNavComponent.isVisible() {
+            EditorFlow.returnToMainEditorScreen()
+            editorScreen.closeEditor()
+        }
+        LoginFlow.logoutIfNeeded()
+        super.tearDown()
+    }
 
     func testTextPostPublish() throws {
         try skipTillBloggingRemindersAreHandled()

--- a/WordPress/WordPressUITests/Tests/SitePageTests.swift
+++ b/WordPress/WordPressUITests/Tests/SitePageTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+class SitePageTests: XCTestCase {
+    private var sitePageEditorScreen: SitePageScreen!
+    override func setUp() {
+        setUpTestSuite()
+        _ = LoginFlow.loginIfNeeded (siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        sitePageEditorScreen = EditorFlow.gotoMySiteScreen()
+            .tabBar.gotoSitePageEditorScreen()
+    }
+
+    func testCreateNewPageFromLayout() {
+        let title = getRandomPhrase()
+        sitePageEditorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .selectALayout()
+            .enterTextInTitle(text: title)
+            .publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+
+    func testCreateNewBlankPage() {
+        let title = getRandomPhrase()
+        sitePageEditorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .tapOnCreateBlankPageButton()
+            .enterTextInTitle(text: title)
+            .publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+
+    func testCreateNewPageWithFeaturedImage() {
+        let title = getRandomPhrase()
+        sitePageEditorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
+            .tapOnCreateBlankPageButton()
+            .enterTextInTitle(text: title)
+            .openPageSettings()
+            .setFeaturedImage()
+            .verifyPostSettings(hasImage: true)
+            .closePostSettings()
+        BlockEditorScreen().publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+}

--- a/WordPress/WordPressUITests/Tests/StoryPageTests.swift
+++ b/WordPress/WordPressUITests/Tests/StoryPageTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+class StoryPageTests: XCTestCase {
+    private var storyPostEditorScreen: StoryPageScreen!
+    override func setUp() {
+        setUpTestSuite()
+        _ = LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        storyPostEditorScreen = EditorFlow.gotoMySiteScreen()
+            .tabBar.gotoStoryPostEditorScreen()
+    }
+
+    func testCreateAStoryUsingPhotos() {
+        storyPostEditorScreen
+            .pickAnImageFromMedia()
+    }
+}


### PR DESCRIPTION
Insert new automated TCs for Posting/Editing
Site Page related changes:
- New TC "Create new page from layout" on "SitePageTests.swift"
- New TC "Create new page from blank page" on "SitePageTests.swift"
- New TC "Add a featured image" on "SitePageTests.swift"
- New page controller on "SitePageScreen.swift"
- New functions for Site Page on "SitePageSettings.swift"

Blog Posts related changes:
- New TC "Create a scheduled post" on "EditorGutenbergTests.swift"
- New TC "Add featured image" on "EditorGutenbergTests.swift"
- New TC "Insert different content media type from within the editor and post" on "EditorGutenbergTests.swift"
- New functions on "BlockEditorScreen.swift" and "EditorPostSettings.swift"

Story Page related changes:
- Started (not completed) new TC "Create a story" on "StoryPageTests.swift"
- Call to activity page on "TabNavComponent.swift"
- New page controller on "StoryPageScreen.swift"
- New functions for Story Page on "StoryPageScreen.swift"